### PR TITLE
only increment counter at the same level

### DIFF
--- a/_sass/custom/table-of-contents.scss
+++ b/_sass/custom/table-of-contents.scss
@@ -3,7 +3,7 @@
   list-style: none;
   counter-reset: my-awesome-counter;
 }
-.page-content ol li {
+.page-content > ol > li {
   counter-increment: my-awesome-counter;
 }
 .page-content ol li::before {


### PR DESCRIPTION
This fixes the table of contents numbering, so it doesn't increment the top level numbering with sub levels.